### PR TITLE
Visual Studio 2019 compatibility update

### DIFF
--- a/samples/BasicXrApp/pch.h
+++ b/samples/BasicXrApp/pch.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <array>
 #include <map>
+#include <unordered_map>
 #include <algorithm>
 #include <assert.h>
 


### PR DESCRIPTION
Simply adds #include <unordered_map> to pch.h so the project will build in Visual Studio 2019