### PR TITLE
Fixed a bug of cube initial location.

### DIFF
--- a/samples/BasicXrApp/OpenXrProgram.cpp
+++ b/samples/BasicXrApp/OpenXrProgram.cpp
@@ -245,8 +245,9 @@ namespace {
                 CHECK_XRCMD(xrCreateReferenceSpace(m_session.Get(), &spaceCreateInfo, m_sceneSpace.Put()));
 
                 // Initialize the placed cube 1 meter in front of user.
-                m_placedCube.Space = m_sceneSpace.Get();
-                m_placedCube.Pose = Pose::Translation({0, 0, -1});
+                spaceCreateInfo.poseInReferenceSpace = Pose::Translation({0, 0, -1});
+                CHECK_XRCMD(xrCreateReferenceSpace(m_session.Get(), &spaceCreateInfo, m_placedCubeSpace.Put()));
+                m_placedCube.Space = m_placedCubeSpace.Get();
                 m_placedCube.Scale = {0.1f, 0.1f, 0.1f};
             }
 

--- a/samples/BasicXrApp/pch.h
+++ b/samples/BasicXrApp/pch.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <array>
 #include <map>
+#include <list>
 #include <unordered_map>
 #include <algorithm>
 #include <assert.h>


### PR DESCRIPTION
Initialize cube's space instead of pose parameter because the cube's pose is auto updated in Update function based on the Space parameter. 

This fix is to address #5 and #4 