### PR TITLE
Update to latest NuGet with packaging fix

### DIFF
--- a/samples/BasicXrApp/BasicXrApp_uwp.vcxproj
+++ b/samples/BasicXrApp/BasicXrApp_uwp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1b09b21c-2d7a-4278-81c8-84a47d5834a7}</ProjectGuid>
     <Keyword>HolographicApp</Keyword>
@@ -144,13 +144,13 @@
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.2\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.2.1\build\native\OpenXR.Loader.targets'))" />
   </Target>
 </Project>

--- a/samples/BasicXrApp/packages.config
+++ b/samples/BasicXrApp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.2" targetFramework="native" />
+  <package id="OpenXR.Loader" version="1.0.2.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This new version of the NuGet package fixes an intermittent error where the UWP app package doesn't contain the loader DLL.